### PR TITLE
Fix failed to run e2e-test on go1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ integration-test:
 e2e-test:
 	test/e2e/run-test.sh
 
+.PHONY: e2e-bootstrap
+e2e-bootstrap:
+	deploy/install-driver.sh
+
+.PHONY: e2e-teardown
+e2e-teardown:
+	deploy/uninstall-driver.sh
+
 .PHONY: blobfuse
 blobfuse:
 	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,12 +1,16 @@
 ## End to End Test
 
 ## Run E2E tests Locally
+
 ### Prerequisite
+
  - Make sure a kubernetes cluster(with version >= 1.13) is set up and kubeconfig is under `$HOME/.kube/config`
  - Copy out `/etc/kubernetes/azure.json` under one agent node to local machine
+ - Set `AZURE_CREDENTIAL_FILE` env variable to path of file copied from `/etc/kubernetes/azure.json`
  > For AKS cluster, need to modify `resourceGroup` to the node resource group name inside `/etc/kubernetes/azure.json`
 
 ### Run test
+
 ```
 make e2e-test
 ```

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -16,20 +16,11 @@
 
 set -uo pipefail
 
-kubectl get daemonsets csi-blobfuse-node -n kube-system; checkBlobFuseDriver=$?;
-if [ $checkBlobFuseDriver -ne 0 ]; then
-    echo "BlobFuse csi driver daemonset not found";
-    echo "Installing BlobFuse csi driver";
-    deploy/install-driver.sh
-    echo "BlobFuse csi driver installed";    
-fi
-
 # Fetching ginkgo for running the test
 GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
-# Exporting KUBECONFIG path
-export KUBECONFIG=$HOME/.kube/config
+
 # Running the e2e test
-ginkgo test/e2e
+ginkgo -v test/e2e
 # Checking for test status
 TEST_PASS=$?
 if [[ $TEST_PASS -ne 0 ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix failed to run e2e-test on go1.13

Instead of calling `framework.HandleFlags()` in `init()` function, I move it to `ginkgo.BeforeSuite`.
And adding installing and uninstalling driver in suite test like `azuredisk-csi-driver` do.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
