### PR TITLE
test: add the e2e test "use existing credentials in k8s cluster"

### DIFF
--- a/pkg/blobfuse/blobfuse.go
+++ b/pkg/blobfuse/blobfuse.go
@@ -113,7 +113,7 @@ func (d *Driver) Run(endpoint string) {
 // get container info according to volume id, e.g.
 // input: "rg#f5713de20cde511e8ba4900#pvc-fuse-dynamic-17e43f84-f474-11e8-acd0-000d3a00df41"
 // output: rg, f5713de20cde511e8ba4900, pvc-fuse-dynamic-17e43f84-f474-11e8-acd0-000d3a00df41
-func getContainerInfo(id string) (string, string, string, error) {
+func GetContainerInfo(id string) (string, string, string, error) {
 	segments := strings.Split(id, separator)
 	if len(segments) < 3 {
 		return "", "", "", fmt.Errorf("error parsing volume id: %q, should at least contain two #", id)
@@ -284,7 +284,7 @@ func (d *Driver) getStorageAccountAndContainer(ctx context.Context, volumeID str
 	} else {
 		if len(secrets) == 0 {
 			var resourceGroupName string
-			resourceGroupName, accountName, containerName, err = getContainerInfo(volumeID)
+			resourceGroupName, accountName, containerName, err = GetContainerInfo(volumeID)
 			if err != nil {
 				return "", "", "", "", err
 			}

--- a/pkg/blobfuse/blobfuse_test.go
+++ b/pkg/blobfuse/blobfuse_test.go
@@ -107,10 +107,10 @@ func TestGetContainerInfo(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result1, result2, result3, result4 := getContainerInfo(test.options)
+		result1, result2, result3, result4 := GetContainerInfo(test.options)
 		if !reflect.DeepEqual(result1, test.expected1) || !reflect.DeepEqual(result2, test.expected2) ||
 			!reflect.DeepEqual(result3, test.expected3) || !reflect.DeepEqual(result4, test.expected4) {
-			t.Errorf("input: %q, getContainerInfo result1: %q, expected1: %q, result2: %q, expected2: %q, result3: %q, expected3: %q, result4: %q, expected4: %q", test.options, result1, test.expected1, result2, test.expected2,
+			t.Errorf("input: %q, GetContainerInfo result1: %q, expected1: %q, result2: %q, expected2: %q, result3: %q, expected3: %q, result4: %q, expected4: %q", test.options, result1, test.expected1, result2, test.expected2,
 				result3, test.expected3, result4, test.expected4)
 		}
 	}

--- a/pkg/blobfuse/controllerserver.go
+++ b/pkg/blobfuse/controllerserver.go
@@ -134,9 +134,9 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	}
 
 	volumeID := req.VolumeId
-	resourceGroupName, accountName, containerName, err := getContainerInfo(volumeID)
+	resourceGroupName, accountName, containerName, err := GetContainerInfo(volumeID)
 	if err != nil {
-		klog.Errorf("getContainerInfo(%s) in DeleteVolume failed with error: %v", volumeID, err)
+		klog.Errorf("GetContainerInfo(%s) in DeleteVolume failed with error: %v", volumeID, err)
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
@@ -183,9 +183,9 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 	}
 
 	volumeID := req.VolumeId
-	resourceGroupName, accountName, containerName, err := getContainerInfo(volumeID)
+	resourceGroupName, accountName, containerName, err := GetContainerInfo(volumeID)
 	if err != nil {
-		klog.Errorf("getContainerInfo(%s) in ValidateVolumeCapabilities failed with error: %v", volumeID, err)
+		klog.Errorf("GetContainerInfo(%s) in ValidateVolumeCapabilities failed with error: %v", volumeID, err)
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 

--- a/test/e2e/driver/blobfuse_csi_driver.go
+++ b/test/e2e/driver/blobfuse_csi_driver.go
@@ -86,6 +86,12 @@ func (d *blobFuseCSIDriver) GetPersistentVolume(volumeID string, fsType string, 
 	}
 }
 
+func (d *blobFuseCSIDriver) GetPreProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass {
+	provisioner := d.driverName
+	generateName := fmt.Sprintf("%s-%s-pre-provisioned-sc-", namespace, provisioner)
+	return getStorageClass(generateName, provisioner, parameters, mountOptions, reclaimPolicy, bindingMode, nil)
+}
+
 func GetParameters() map[string]string {
 	return map[string]string{
 		"skuName": "Standard_LRS",

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -44,6 +44,8 @@ type DynamicPVTestDriver interface {
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
 	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+	// GetPreProvisionStorageClass returns a StorageClass with existing container
+	GetPreProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass
 }
 
 type VolumeSnapshotTestDriver interface {

--- a/test/e2e/testsuites/pre_provisioned_existing_credentials_tester.go
+++ b/test/e2e/testsuites/pre_provisioned_existing_credentials_tester.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+
+	"sigs.k8s.io/blobfuse-csi-driver/pkg/blobfuse"
+	"sigs.k8s.io/blobfuse-csi-driver/test/e2e/driver"
+
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// DynamicallyProvisionedCmdVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)
+// Waiting for the PV provisioner to create a new PV
+// Testing if the Pod(s) Cmd is run with a 0 exit code
+type PreProvisionedExistingCredentialsTest struct {
+	CSIDriver driver.PreProvisionedVolumeTestDriver
+	Pods      []PodDetails
+}
+
+func (t *PreProvisionedExistingCredentialsTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	for _, pod := range t.Pods {
+		for n, volume := range pod.Volumes {
+			resourceGroupName, accountName, containerName, err := blobfuse.GetContainerInfo(volume.VolumeID)
+			if err != nil {
+				framework.ExpectNoError(err, fmt.Sprintf("Error GetContainerInfo from volumeID(%s): %v", volume.VolumeID, err))
+				return
+			}
+			parameters := map[string]string{
+				"resourceGroup":  resourceGroupName,
+				"storageAccount": accountName,
+				"containerName":  containerName,
+			}
+
+			ginkgo.By("creating the storageclass with existing credentials")
+			sc := t.CSIDriver.GetPreProvisionStorageClass(parameters, volume.MountOptions, volume.ReclaimPolicy, volume.VolumeBindingMode, volume.AllowedTopologyValues, namespace.Name)
+			tsc := NewTestStorageClass(client, namespace, sc)
+			createdStorageClass := tsc.Create()
+			defer tsc.Cleanup()
+
+			ginkgo.By("creating pvc with storageclass")
+			tpvc := NewTestPersistentVolumeClaim(client, namespace, volume.ClaimSize, volume.VolumeMode, &createdStorageClass)
+			tpvc.Create()
+			defer tpvc.Cleanup()
+
+			ginkgo.By("validating the pvc")
+			tpvc.WaitForBound()
+			tpvc.ValidateProvisionedPersistentVolume()
+
+			tpod := NewTestPod(client, namespace, pod.Cmd)
+			tpod.SetupVolume(tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", volume.VolumeMount.NameGenerate, n+1), fmt.Sprintf("%s%d", volume.VolumeMount.MountPathGenerate, n+1), volume.VolumeMount.ReadOnly)
+			ginkgo.By("deploying the pod")
+			tpod.Create()
+			defer tpod.Cleanup()
+			ginkgo.By("checking that the pods command exits with no error")
+			tpod.WaitForSuccess()
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Ref: [Option#1: use existing credentials in k8s cluster](https://github.com/kubernetes-sigs/blobfuse-csi-driver/blob/master/deploy/example/e2e_usage.md#option1-use-existing-credentials-in-k8s-cluster)


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80 

**Special notes for your reviewer**:


**Release note**:
```

```
