### PR TITLE
fix corrupted mount issue when driver daemonset restarted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ blobfuse-windows:
 	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
 	CGO_ENABLED=0 GOOS=windows go build -a -ldflags ${LDFLAGS} -o _output/blobfuseplugin.exe ./pkg/blobfuseplugin
 
+.PHONY: container
+container: blobfuse
+	docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/blobfuseplugin/Dockerfile .
+
 .PHONY: blobfuse-container
 blobfuse-container: blobfuse
 	docker build --no-cache -t $(IMAGE_TAG) -f ./pkg/blobfuseplugin/Dockerfile .

--- a/deploy/example/blobfuse-deployment.yaml
+++ b/deploy/example/blobfuse-deployment.yaml
@@ -1,0 +1,50 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-blobfuse
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: blobfuse.csi.azure.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: deployment-blobfuse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      name: deployment-blobfuse
+    spec:
+      containers:
+        - name: deployment-blobfuse
+          image: nginx
+          command:
+            - "/bin/sh"
+            - "-c"
+            - while true; do echo $(date) >> /mnt/blobfuse/outfile; sleep 1; done
+          volumeMounts:
+            - name: blobfuse
+              mountPath: "/mnt/blobfuse"
+              readOnly: false
+      volumes:
+        - name: blobfuse
+          persistentVolumeClaim:
+            claimName: pvc-blobfuse
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/deploy/example/blobfuse-statefulset.yaml
+++ b/deploy/example/blobfuse-statefulset.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-blobfuse
+  labels:
+    app: nginx
+spec:
+  serviceName: statefulset-blobfuse
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: statefulset-blobfuse
+          image: nginx
+          command:
+            - "/bin/sh"
+            - "-c"
+            - while true; do echo $(date) >> /mnt/blobfuse/outfile; sleep 1; done
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /mnt/blobfuse
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: nginx
+  volumeClaimTemplates:
+    - metadata:
+        name: persistent-storage
+        annotations:
+          volume.beta.kubernetes.io/storage-class: blobfuse.csi.azure.com
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi

--- a/pkg/blobfuse/blobfuse.go
+++ b/pkg/blobfuse/blobfuse.go
@@ -311,3 +311,9 @@ func (d *Driver) getStorageAccountAndContainer(ctx context.Context, volumeID str
 
 	return accountName, accountKey, accountSasToken, containerName, nil
 }
+
+func IsCorruptedDir(dir string) bool {
+	pathExists, pathErr := mount.PathExists(dir)
+	fmt.Printf("IsCorruptedDir(%s) returned with error: (%v, %v)\\n", dir, pathExists, pathErr)
+	return pathErr != nil && mount.IsCorruptedMnt(pathErr)
+}

--- a/pkg/blobfuse/blobfuse_test.go
+++ b/pkg/blobfuse/blobfuse_test.go
@@ -18,6 +18,8 @@ package blobfuse
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -347,5 +349,35 @@ func TestIsSASToken(t *testing.T) {
 		if !reflect.DeepEqual(result, test.expected) {
 			t.Errorf("input: %q, isSASToken result: %v, expected: %v", test.key, result, test.expected)
 		}
+	}
+}
+
+func TestIsCorruptedDir(t *testing.T) {
+	existingMountPath, err := ioutil.TempDir(os.TempDir(), "blobfuse-csi-mount-test")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %v", err)
+	}
+	defer os.RemoveAll(existingMountPath)
+
+	tests := []struct {
+		desc           string
+		dir            string
+		expectedResult bool
+	}{
+		{
+			desc:           "NotExist dir",
+			dir:            "/tmp/NotExist",
+			expectedResult: false,
+		},
+		{
+			desc:           "Existing dir",
+			dir:            existingMountPath,
+			expectedResult: false,
+		},
+	}
+
+	for i, test := range tests {
+		isCorruptedDir := IsCorruptedDir(test.dir)
+		assert.Equal(t, test.expectedResult, isCorruptedDir, "TestCase[%d]: %s", i, test.desc)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR together with an k8s upstream PR(https://github.com/kubernetes/kubernetes/pull/88569) would fix the  corrupted mount issue when fuse based CSI driver daemonset is restarted on the node:
after daemonset is restarted, original blobfuse mount is broken, this PR would handle broken mount in both `NodeStage` and `NodePublish`
 - detect the broken mount path
 - unmount broken mount path
 - remount mount path

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115

**Special notes for your reviewer**:
Main fix is in `ensureMountPoint` func:

```
func (d *Driver) ensureMountPoint(target string) error {
	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
	if err != nil && !os.IsNotExist(err) {
		if IsCorruptedDir(target) {
			notMnt = false
			klog.Warningf("detected corrupted mount for targetPath [%s]", target)
		} else {
			return err
		}
	}
...
```

main code exection logic for this PR:
```
I0226 03:37:10.191769       1 utils.go:112] GRPC call: /csi.v1.Node/NodeStageVolume
I0226 03:37:10.191800       1 utils.go:113] GRPC request: volume_id:"andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338" staging_target_path:"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount" volume_capability:<mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > > volume_context:<key:"skuName" value:"Standard_LRS" > volume_context:<key:"storage.kubernetes.io/csiProvisionerIdentity" value:"1582552362270-8081-blobfuse.csi.azure.com" >
I0226 03:37:10.191810       1 nodeserver.go:105] NodeStageVolume: called with args {VolumeId:andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338 PublishContext:map[] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER >  Secrets:map[] VolumeContext:map[skuName:Standard_LRS storage.kubernetes.io/csiProvisionerIdentity:1582552362270-8081-blobfuse.csi.azure.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
W0226 03:37:10.191901       1 nodeserver.go:241] detected corrupted mount for targetPath [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount]
W0226 03:37:10.191917       1 nodeserver.go:255] ReadDir /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount failed with open /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount: transport endpoint is not connected, unmount this directory
I0226 03:37:10.191925       1 mount_linux.go:209] Unmounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount
I0226 03:37:10.674579       1 nodeserver.go:141] target /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount
fstype ext4

volumeId andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338
context map[skuName:Standard_LRS storage.kubernetes.io/csiProvisionerIdentity:1582552362270-8081-blobfuse.csi.azure.com]
mountflags []
mountOptions [--use-https=true]
args /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount --tmp-path=/mnt/andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338 --container-name=pvc-0433847e-03fd-422f-b053-5534510eb338 --use-https=true

I0226 03:37:10.813063       1 utils.go:113] GRPC request: volume_id:"andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338" staging_target_path:"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount" target_path:"/var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount" volume_capability:<mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > > volume_context:<key:"skuName" value:"Standard_LRS" > volume_context:<key:"storage.kubernetes.io/csiProvisionerIdentity" value:"1582552362270-8081-blobfuse.csi.azure.com" >
I0226 03:37:10.813074       1 nodeserver.go:39] NodePublishVolume: called with args {VolumeId:andy-1180alpha5#fuse9e6bc1063ad742c8a12#pvc-0433847e-03fd-422f-b053-5534510eb338 PublishContext:map[] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount TargetPath:/var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[skuName:Standard_LRS storage.kubernetes.io/csiProvisionerIdentity:1582552362270-8081-blobfuse.csi.azure.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
W0226 03:37:10.813124       1 nodeserver.go:241] detected corrupted mount for targetPath [/var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount]
W0226 03:37:10.813142       1 nodeserver.go:255] ReadDir /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount failed with open /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount: transport endpoint is not connected, unmount this directory
I0226 03:37:10.813152       1 mount_linux.go:209] Unmounting /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount
I0226 03:37:10.819437       1 nodeserver.go:69] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount at /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount with mountOptions: [bind]
I0226 03:37:10.819461       1 mount_linux.go:142] Mounting cmd (mount) with arguments ([-o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount])
I0226 03:37:10.821022       1 mount_linux.go:142] Mounting cmd (mount) with arguments ([-o bind,remount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount])
I0226 03:37:10.824341       1 nodeserver.go:76] NodePublishVolume: mount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0433847e-03fd-422f-b053-5534510eb338/globalmount at /var/lib/kubelet/pods/8a2a3fdd-f52c-460b-b270-d7cc00ae7ed5/volumes/kubernetes.io~csi/pvc-0433847e-03fd-422f-b053-5534510eb338/mount successfully

```

**Release note**:
```
fix corrupted mount issue when driver deamonset restarted
```
