### PR TITLE
test: add the e2e test "should use provided credentials"

### DIFF
--- a/pkg/blobfuse/blobfuse.go
+++ b/pkg/blobfuse/blobfuse.go
@@ -236,9 +236,9 @@ func isSASToken(key string) bool {
 	return strings.Contains(key, "?sv=")
 }
 
-// getStorageAccountAndContainer: get storage account and container info
+// GetStorageAccountAndContainer: get storage account and container info
 // returns <accountName, accountKey, accountSasToken, containerName>
-func (d *Driver) getStorageAccountAndContainer(ctx context.Context, volumeID string, attrib, secrets map[string]string) (string, string, string, string, error) {
+func (d *Driver) GetStorageAccountAndContainer(ctx context.Context, volumeID string, attrib, secrets map[string]string) (string, string, string, string, error) {
 	var (
 		accountName     string
 		accountKey      string

--- a/pkg/blobfuse/nodeserver.go
+++ b/pkg/blobfuse/nodeserver.go
@@ -126,7 +126,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	attrib := req.GetVolumeContext()
 	secrets := req.GetSecrets()
 
-	accountName, accountKey, accountSasToken, containerName, err := d.getStorageAccountAndContainer(ctx, volumeID, attrib, secrets)
+	accountName, accountKey, accountSasToken, containerName, err := d.GetStorageAccountAndContainer(ctx, volumeID, attrib, secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, in *csi.NodeGetVolumeSt
 
 // NodeExpandVolume node expand volume
 func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, fmt.Sprintf("NodeExpandVolume is not yet implemented"))
+	return nil, status.Error(codes.Unimplemented, "NodeExpandVolume is not yet implemented")
 }
 
 // ensureMountPoint: create mount point if not exists

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -43,7 +43,7 @@ type DynamicPVTestDriver interface {
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
-	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, attrib map[string]string, nodeStageSecretRef string) *v1.PersistentVolume
 	// GetPreProvisionStorageClass returns a StorageClass with existing container
 	GetPreProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass
 }

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[blobfuse-csi-e2e] Dynamic Provisioning", func() {
 	})
 
 	testDriver = driver.InitBlobFuseCSIDriver()
-	ginkgo.It(fmt.Sprintf("should create a volume on demand"), func() {
+	ginkgo.It("should create a volume on demand", func() {
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -91,13 +91,13 @@ var _ = ginkgo.BeforeSuite(func() {
 		}
 		execTestCmd([]testCmd{e2eBootstrap})
 
-		nodeid := os.Getenv("nodeid")
-		blobfuseDriver = blobfuse.NewDriver(nodeid)
-		go func() {
-			os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
-			blobfuseDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()))
-		}()
 	}
+	nodeid := os.Getenv("nodeid")
+	blobfuseDriver = blobfuse.NewDriver(nodeid)
+	go func() {
+		os.Setenv("AZURE_CREDENTIAL_FILE", credentials.TempAzureCredentialFilePath)
+		blobfuseDriver.Run(fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()))
+	}()
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/test/e2e/testsuites/pre_provisioned_existing_credentials_tester.go
+++ b/test/e2e/testsuites/pre_provisioned_existing_credentials_tester.go
@@ -29,9 +29,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-// DynamicallyProvisionedCmdVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)
-// Waiting for the PV provisioner to create a new PV
-// Testing if the Pod(s) Cmd is run with a 0 exit code
+// PreProvisionedExistingCredentialsTest will provision required StorageClass(es), PVC(s) and Pod(s)
+// Testing that the Pod(s) can be created successfully with existing credentials in k8s cluster
 type PreProvisionedExistingCredentialsTest struct {
 	CSIDriver driver.PreProvisionedVolumeTestDriver
 	Pods      []PodDetails

--- a/test/e2e/testsuites/pre_provisioned_provided_credentials_tester.go
+++ b/test/e2e/testsuites/pre_provisioned_provided_credentials_tester.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+
+	"sigs.k8s.io/blobfuse-csi-driver/pkg/blobfuse"
+	"sigs.k8s.io/blobfuse-csi-driver/test/e2e/driver"
+
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// PreProvisionedProvidedCredentiasTest will provision required PV(s), PVC(s) and Pod(s)
+// Testing that the Pod(s) can be created successfully with provided storage account name and key(or sastoken)
+type PreProvisionedProvidedCredentiasTest struct {
+	CSIDriver driver.PreProvisionedVolumeTestDriver
+	Pods      []PodDetails
+	Blobfuse  *blobfuse.Driver
+}
+
+func (t *PreProvisionedProvidedCredentiasTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	for _, pod := range t.Pods {
+		for n, volume := range pod.Volumes {
+			accountName, accountKey, accountSasToken, containerName, err := t.Blobfuse.GetStorageAccountAndContainer(context.Background(), volume.VolumeID, nil, nil)
+			framework.ExpectNoError(err, fmt.Sprintf("Error GetStorageAccountAndContainer from volumeID(%s): %v", volume.VolumeID, err))
+
+			ginkgo.By("creating the secret")
+			secreteData := map[string]string{"azurestorageaccountname": accountName}
+			if accountKey != "" {
+				secreteData["azurestorageaccountkey"] = accountKey
+			} else {
+				secreteData["azurestorageaccountsastoken"] = accountSasToken
+			}
+			tsecret := NewTestSecret(client, namespace, volume.NodeStageSecretRef, secreteData)
+			tsecret.Create()
+			defer tsecret.Cleanup()
+
+			pod.Volumes[n].ContainerName = containerName
+			tpod, cleanup := pod.SetupWithPreProvisionedVolumes(client, namespace, t.CSIDriver)
+			// defer must be called here for resources not get removed before using them
+			for i := range cleanup {
+				defer cleanup[i]()
+			}
+
+			ginkgo.By("deploying the pod")
+			tpod.Create()
+			defer tpod.Cleanup()
+			ginkgo.By("checking that the pods command exits with no error")
+			tpod.WaitForSuccess()
+		}
+	}
+}

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -48,7 +48,9 @@ type VolumeDetails struct {
 	// Optional, used with pre-provisioned volumes
 	VolumeID string
 	// Optional, used with PVCs created from snapshots
-	DataSource *DataSource
+	DataSource         *DataSource
+	ContainerName      string
+	NodeStageSecretRef string
 }
 
 type VolumeMode int
@@ -168,7 +170,12 @@ func (volume *VolumeDetails) SetupDynamicPersistentVolumeClaim(client clientset.
 func (volume *VolumeDetails) SetupPreProvisionedPersistentVolumeClaim(client clientset.Interface, namespace *v1.Namespace, csiDriver driver.PreProvisionedVolumeTestDriver) (*TestPersistentVolumeClaim, []func()) {
 	cleanupFuncs := make([]func(), 0)
 	ginkgo.By("setting up the PV")
-	pv := csiDriver.GetPersistentVolume(volume.VolumeID, volume.FSType, volume.ClaimSize, volume.ReclaimPolicy, namespace.Name)
+	attrib := make(map[string]string)
+	if volume.ContainerName != "" {
+		attrib["containerName"] = volume.ContainerName
+	}
+	nodeStageSecretRef := volume.NodeStageSecretRef
+	pv := csiDriver.GetPersistentVolume(volume.VolumeID, volume.FSType, volume.ClaimSize, volume.ReclaimPolicy, namespace.Name, attrib, nodeStageSecretRef)
 	tpv := NewTestPreProvisionedPersistentVolume(client, pv)
 	tpv.Create()
 	ginkgo.By("setting up the PVC")

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -595,6 +595,38 @@ func (t *TestPod) Logs() ([]byte, error) {
 	return podLogs(t.client, t.pod.Name, t.namespace.Name)
 }
 
+type TestSecret struct {
+	client    clientset.Interface
+	secret    *v1.Secret
+	namespace *v1.Namespace
+}
+
+func NewTestSecret(c clientset.Interface, ns *v1.Namespace, name string, data map[string]string) *TestSecret {
+	return &TestSecret{
+		client:    c,
+		namespace: ns,
+		secret: &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			StringData: data,
+			Type:       v1.SecretTypeOpaque,
+		},
+	}
+}
+
+func (t *TestSecret) Create() {
+	var err error
+	t.secret, err = t.client.CoreV1().Secrets(t.namespace.Name).Create(t.secret)
+	framework.ExpectNoError(err)
+}
+
+func (t *TestSecret) Cleanup() {
+	e2elog.Logf("deleting Secret %s", t.secret.Name)
+	err := t.client.CoreV1().Secrets(t.namespace.Name).Delete(t.secret.Name, nil)
+	framework.ExpectNoError(err)
+}
+
 func cleanupPodOrFail(client clientset.Interface, name, namespace string) {
 	e2elog.Logf("deleting Pod %q/%q", namespace, name)
 	body, err := podLogs(client, name, namespace)


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Ref: [Option#2: provide storage account name and key(or sastoken)](https://github.com/kubernetes-sigs/blobfuse-csi-driver/blob/master/deploy/example/e2e_usage.md#option2-provide-storage-account-name-and-keyor-sastoken)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80 

**Special notes for your reviewer**:


**Release note**:
```
add the e2e test "should use provided credentials"
```
