### PR TITLE
test: add negative mount options e2e test

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -232,4 +232,32 @@ var _ = ginkgo.Describe("[blobfuse-csi-e2e] Dynamic Provisioning", func() {
 		}
 		test.Run(cs, ns)
 	})
+
+	ginkgo.It("should receive FailedMount event with invalid mount options", func() {
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"invalid",
+							"mount",
+							"options",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedInvalidMountOptions{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: map[string]string{"skuName": "Standard_LRS"},
+		}
+		test.Run(cs, ns)
+	})
 })

--- a/test/e2e/testsuites/dynamically_provisioned_invalid_mount_options.go
+++ b/test/e2e/testsuites/dynamically_provisioned_invalid_mount_options.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"sigs.k8s.io/blobfuse-csi-driver/test/e2e/driver"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// DynamicallyProvisionedInvalidMountOptions will provision a storage class with invalid mount options
+// Testing if the Pod(s) Cmd is run with a 0 exit code
+type DynamicallyProvisionedInvalidMountOptions struct {
+	CSIDriver              driver.DynamicPVTestDriver
+	Pods                   []PodDetails
+	StorageClassParameters map[string]string
+}
+
+func (t *DynamicallyProvisionedInvalidMountOptions) Run(client clientset.Interface, namespace *v1.Namespace) {
+	for _, pod := range t.Pods {
+		tpod, cleanup := pod.SetupWithDynamicVolumes(client, namespace, t.CSIDriver, t.StorageClassParameters)
+		// defer must be called here for resources not get removed before using them
+		for i := range cleanup {
+			defer cleanup[i]()
+		}
+
+		ginkgo.By("deploying the pod")
+		tpod.Create()
+		defer tpod.Cleanup()
+		ginkgo.By("checking that the pod has 'FailedMount' event")
+		tpod.WaitForFailedMountError()
+	}
+}

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -33,9 +33,12 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -453,6 +456,16 @@ func (t *TestPod) WaitForSuccess() {
 
 func (t *TestPod) WaitForRunning() {
 	err := e2epod.WaitForPodRunningInNamespace(t.client, t.pod)
+	framework.ExpectNoError(err)
+}
+
+func (t *TestPod) WaitForFailedMountError() {
+	err := e2eevents.WaitTimeoutForEvent(
+		t.client,
+		t.namespace.Name,
+		fields.Set{"reason": events.FailedMountVolume}.AsSelector().String(),
+		"",
+		pollLongTimeout)
 	framework.ExpectNoError(err)
 }
 

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/events/BUILD
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/events/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["events.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework/events",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/events/events.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/events/events.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// WaitTimeoutForEvent waits the given timeout duration for an event to occur.
+func WaitTimeoutForEvent(c clientset.Interface, namespace, eventSelector, msg string, timeout time.Duration) error {
+	interval := 2 * time.Second
+	return wait.PollImmediate(interval, timeout, eventOccurred(c, namespace, eventSelector, msg))
+}
+
+func eventOccurred(c clientset.Interface, namespace, eventSelector, msg string) wait.ConditionFunc {
+	options := metav1.ListOptions{FieldSelector: eventSelector}
+	return func() (bool, error) {
+		events, err := c.CoreV1().Events(namespace).List(context.TODO(), options)
+		if err != nil {
+			return false, fmt.Errorf("got error while getting events: %v", err)
+		}
+		for _, event := range events.Items {
+			if strings.Contains(event.Message, msg) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -744,6 +744,7 @@ k8s.io/kubernetes/pkg/volume/util/volumepathhandler
 k8s.io/kubernetes/test/e2e/framework
 k8s.io/kubernetes/test/e2e/framework/auth
 k8s.io/kubernetes/test/e2e/framework/config
+k8s.io/kubernetes/test/e2e/framework/events
 k8s.io/kubernetes/test/e2e/framework/ginkgowrapper
 k8s.io/kubernetes/test/e2e/framework/kubectl
 k8s.io/kubernetes/test/e2e/framework/log


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: add negative mount options e2e test

blocked by :
```
# hack/verify-all.sh
Verifying gofmt
No issue found
Verifying govet
# sigs.k8s.io/blobfuse-csi-driver/test/e2e/testsuites
test/e2e/testsuites/testsuites.go:535:4: cannot use t.client (type "sigs.k8s.io/blobfuse-csi-driver/vendor/k8s.io/client-go/kubernetes".Interface) as type "k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes".Interface in argument to "k8s.io/kubernetes/test/e2e/framework/events".WaitTimeoutForEvent:
        "sigs.k8s.io/blobfuse-csi-driver/vendor/k8s.io/client-go/kubernetes".Interface does not implement "k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes".Interface (missing AdmissionregistrationV1 method)
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #96 

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
